### PR TITLE
Update chat.jade

### DIFF
--- a/ch02/views/chat.jade
+++ b/ch02/views/chat.jade
@@ -1,8 +1,8 @@
 extends layout
 
 block scripts
-  script(type='text/javascript', src='/socket.io/socket.io.js')
-  script(type='text/javascript')
+  script(src='/socket.io/socket.io.js')
+  script.
     var socket = io.connect('http://localhost:8080');
     socket.on('chat', function(data) {
       document.getElementById('chat').innerHTML =


### PR DESCRIPTION
Implicit textOnly for `script` is deprecated.  Using `script.` instead.
