### PR TITLE
 is lacking a dot after script tag

### DIFF
--- a/ch02/views/chat.jade
+++ b/ch02/views/chat.jade
@@ -2,7 +2,7 @@ extends layout
 
 block scripts
   script(type='text/javascript', src='/socket.io/socket.io.js')
-  script(type='text/javascript')
+  script(type='text/javascript').
     var socket = io.connect('http://localhost:8080');
     socket.on('chat', function(data) {
       document.getElementById('chat').innerHTML =


### PR DESCRIPTION
because it not have the final dot on inline javascript jade template, results on Syntax Error interrupting the script
